### PR TITLE
Use dotenv for dev environment configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+DATABASE_USER=forwritersuser
+DATABASE_PASSWORD=qwerty123
+DATABASE_NAME=for_writers_development

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+.env.local

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'bootsnap', '>= 1.4.4', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     ffi (1.15.0)
     globalid (0.4.2)
@@ -222,6 +226,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   devise
+  dotenv-rails
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,12 +2,12 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: forwritersuser
-  password: 'qwerty123'
+  username: <%= ENV["DATABASE_USER"] %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>
+  database: <%= ENV["DATABASE_NAME"] %>
 
 development:
   <<: *default
-  database: for_writers_development
 
 test:
   <<: *default
@@ -15,7 +15,3 @@ test:
 
 production:
   <<: *default
-  database: for_writers_production
-  username: forwritersuser
-  password: 'qwerty123'
-  # password: <%= ENV['RAILS_FOR_WRITERS_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
Use `.env` as main storage for all non-sensitive information and as a template. Use `.env.local` for sensitive information related to dev environment